### PR TITLE
Add qemu for arm64

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -23,6 +23,7 @@ jobs:
           - 16j9
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
         with:
           version: "v0.5.1"


### PR DESCRIPTION
Required for multi-architecture builds as right now it doesn't actually successfully build for arm64