### PR TITLE
Adding libstdc++ in java images

### DIFF
--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -27,7 +27,7 @@ LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apk add --update --no-cache ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+RUN         apk add --update --no-cache libstdc++ ca-certificates curl fontconfig git openssl sqlite tar tzdata \
 			    && adduser -D -h /home/container container
 
 USER        container

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -27,7 +27,7 @@ LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apk add --update --no-cache ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+RUN         apk add --update --no-cache libstdc++ ca-certificates curl fontconfig git openssl sqlite tar tzdata \
 			    && adduser -D -h /home/container container
 
 USER        container

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -27,7 +27,7 @@ LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apk add --update --no-cache ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+RUN         apk add --update --no-cache libstdc++ ca-certificates curl fontconfig git openssl sqlite tar tzdata \
 			    && adduser -D -h /home/container container
 
 USER        container

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -27,7 +27,7 @@ LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apk add --update --no-cache ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+RUN         apk add --update --no-cache libstdc++ ca-certificates curl fontconfig git openssl sqlite tar tzdata \
 			    && adduser -D -h /home/container container
 
 USER        container

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -27,7 +27,7 @@ LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apk add --update --no-cache ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+RUN         apk add --update --no-cache libstdc++ ca-certificates curl fontconfig git openssl sqlite tar tzdata \
 			    && adduser -D -h /home/container container
 
 USER        container

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -27,7 +27,7 @@ LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apk add --update --no-cache ca-certificates curl fontconfig git openssl sqlite tar tzdata \
+RUN         apk add --update --no-cache libstdc++ ca-certificates curl fontconfig git openssl sqlite tar tzdata \
 			    && adduser -D -h /home/container container
 
 USER        container


### PR DESCRIPTION
Adding libstdc++ in java images, to solve a dependency problem for the plugin [Spark](https://spark.lucko.me)

Solution proposed directly in the documentation of the plugin: [Plugins Docs](https://spark.lucko.me/docs/misc/Using-async-profiler#install-libstdc)

Test image realized : [Docker Hub](https://hub.docker.com/layers/148717796/thesam1798/test/latest/images/sha256-647ca918f9f5b9f53b81634af861965fb6a3573231230827428f45b7a4d37922?context=repo)