### PR TITLE
fix(openj9): migrate to IBM official semeru openj9 images

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -17,11 +17,11 @@ jobs:
       matrix:
         tag:
           - 8
-          #- 8j9
+          - 8j9
           - 11
-          #- 11j9
+          - 11j9
           - 16
-          #- 16j9
+          - 16j9
           - 17
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -21,8 +21,8 @@ jobs:
           - 11
           - 11j9
           - 16
-          - 16j9
           - 17
+          - 17j9
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ example of this would be something like Java or Python which are used for runnin
 All of these images are available for `linux/amd64` and `linux/arm64` versions, unless otherwise specified, to use
 these images on an arm64 system, no modification to them or the tag is needed, they should just work.
 
-### Contributing
+## Contributing
 
 When adding a new version to an existing image, such as `java v42`, you'd add it within a child folder of `java`, so
 `java/42/Dockerfile` for example. Please also update the correct `.github/workflows` file to ensure that this new version
@@ -61,6 +61,8 @@ is tagged correctly.
     * `ghcr.io/pterodactyl/yolks:java_16j9`
   * [`java17`](https://github.com/pterodactyl/yolks/tree/master/java/17)
     * `ghcr.io/pterodactyl/yolks:java_17`
+  * [`java17 - OpenJ9`](https://github.com/pterodactyl/yolks/tree/master/java/17j9)
+    * `ghcr.io/pterodactyl/yolks:java_17j9`
 * [`nodejs`](https://github.com/pterodactyl/yolks/tree/master/nodejs)
   * [`node12`](https://github.com/pterodactyl/yolks/tree/master/nodejs/12)
     * `ghcr.io/pterodactyl/yolks:nodejs_12`

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-FROM        --platform=$TARGETOS/$TARGETARCH adoptopenjdk/openjdk11-openj9:debianslim
+FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-11-jdk
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-FROM        --platform=$TARGETOS/$TARGETARCH adoptopenjdk/openjdk16-openj9:debianslim
+FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-16-jdk
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/17j9/Dockerfile
+++ b/java/17j9/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2021 Matthew Penner
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+FROM --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-17-jdk
+
+LABEL author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+
+LABEL org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL org.opencontainers.image.licenses=MIT
+
+RUN apt-get update -y &&
+	apt-get install -y curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 &&
+	useradd -d /home/container -m container
+
+USER container
+ENV USER=container HOME=/home/container
+WORKDIR /home/container
+
+COPY ./../entrypoint.sh /entrypoint.sh
+CMD [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/17j9/Dockerfile
+++ b/java/17j9/Dockerfile
@@ -20,20 +20,20 @@
 # SOFTWARE.
 #
 
-FROM --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-17-jdk
+FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-17-jdk
 
-LABEL author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 
-LABEL org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
-LABEL org.opencontainers.image.licenses=MIT
+LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.licenses=MIT
 
-RUN apt-get update -y &&
-	apt-get install -y curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 &&
-	useradd -d /home/container -m container
+RUN 				apt-get update -y \
+						&& apt-get install -y curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+						&& useradd -d /home/container -m container
 
-USER container
-ENV USER=container HOME=/home/container
-WORKDIR /home/container
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
 
-COPY ./../entrypoint.sh /entrypoint.sh
-CMD [ "/bin/bash", "/entrypoint.sh" ]
+COPY        ./../entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/bash", "/entrypoint.sh" ]

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-FROM        --platform=$TARGETOS/$TARGETARCH adoptopenjdk/openjdk8-openj9:debianslim
+FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-8-jdk
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 


### PR DESCRIPTION
AdoptOpenJDK is deprecated and removed. They are no longer maintained for legal licensing reasons after moving to Eclipse. However, IBM Semeru continues to maintain the images. 

16 is EOL and did not make it into Semeru arm64 support release.