### PR TITLE
fix: evaluation with operators

### DIFF
--- a/games/source/entrypoint.sh
+++ b/games/source/entrypoint.sh
@@ -39,7 +39,7 @@ cd /home/container || exit 1
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval "echo \"$(cat -)\""
 
 ## just in case someone removed the defaults.
 if [ "${STEAM_USER}" == "" ]; then

--- a/go/entrypoint.sh
+++ b/go/entrypoint.sh
@@ -40,7 +40,7 @@ go version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval "echo \"$(cat -)\""
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/java/entrypoint.sh
+++ b/java/entrypoint.sh
@@ -40,7 +40,7 @@ java -version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval "echo \"$(cat -)\""
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/nodejs/entrypoint.sh
+++ b/nodejs/entrypoint.sh
@@ -40,7 +40,7 @@ node -v
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval "echo \"$(cat -)\""
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/oses/alpine/entrypoint.sh
+++ b/oses/alpine/entrypoint.sh
@@ -34,7 +34,7 @@ cd /home/container || exit 1
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval "echo \"$(cat -)\""
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/oses/debian/entrypoint.sh
+++ b/oses/debian/entrypoint.sh
@@ -35,7 +35,7 @@ cd /home/container || exit 1
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval "echo \"$(cat -)\""
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -40,7 +40,7 @@ python --version
 # Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
 # variable format of "${VARIABLE}" before evaluating the string and automatically
 # replacing the values.
-PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval "echo \"$(cat -)\""
 
 # Display the command we're running in the output, and then execute it with the env
 # from the container itself.


### PR DESCRIPTION
This PR lets you evaluate a command with operators.

Previously if ${STARTUP} was something like ``{{HOME}} && ls -a`` it would output ``/home/blake . ..`` now it outputs ``/home/blake && ls -a``