### PR TITLE
Use Eclipse Termium images instead of OpenJDK images

### DIFF
--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -25,6 +25,8 @@
 # latest Forge release. This should be removed when the manifest constructor class
 # issue is backported or if Forge decides to abandon old versions and we need
 # newer Java versions. Old Quay images were updated like once a year, so it's ok.
+#
+# @see https://github.com/McModLauncher/modlauncher/issues/91
 
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11.0.13_8-jdk-focal
 

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -26,9 +26,12 @@
 # issue is backported or if Forge decides to abandon old versions and we need
 # newer Java versions. Old Quay images were updated like once a year, so it's ok.
 #
+# Update: This issue has been resolved, see issue below for more info - No767 (Noelle)
+# For reference, the old hard coded version is 11.0.13-slim
+#
 # @see https://github.com/McModLauncher/modlauncher/issues/91
 
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:11.0.13-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11-jdk-jammy
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -25,13 +25,8 @@
 # latest Forge release. This should be removed when the manifest constructor class
 # issue is backported or if Forge decides to abandon old versions and we need
 # newer Java versions. Old Quay images were updated like once a year, so it's ok.
-#
-# Update: This issue has been resolved, see issue below for more info - No767 (Noelle)
-# For reference, the old hard coded version is 11.0.13-slim
-#
-# @see https://github.com/McModLauncher/modlauncher/issues/91
 
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11-jdk-jammy
+FROM        --platform=$TARGETOS/$TARGETARCH openjdk:11.0.13-slim
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -26,7 +26,7 @@
 # issue is backported or if Forge decides to abandon old versions and we need
 # newer Java versions. Old Quay images were updated like once a year, so it's ok.
 
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:11.0.13-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11.0.13_8-jdk-focal
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -21,7 +21,7 @@
 #
 
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:16-jdk-focal
- 
+
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -20,7 +20,8 @@
 # SOFTWARE.
 #
 
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:16-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:16-jdk-focal
+ 
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:17-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/18/Dockerfile
+++ b/java/18/Dockerfile
@@ -20,7 +20,7 @@
 # SOFTWARE.
 #
 
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:18-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:18-jdk-jammy
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -26,7 +26,7 @@
 # issue is backported or if Forge decides to abandon old versions and we need
 # newer Java versions. Old Quay images were updated like once a year, so it's ok.
 
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:8u312-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8u312-b07-jdk-focal
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -25,12 +25,8 @@
 # latest Forge release. This should be removed when the manifest constructor class
 # issue is backported or if Forge decides to abandon old versions and we need
 # newer Java versions. Old Quay images were updated like once a year, so it's ok.
-#
-# Update: This issue has been resolved, see issue below for more info - No767 (Noelle)
-# For reference, the old hard coded version is 8u312-slim
-# @see https://github.com/McModLauncher/modlauncher/issues/91
 
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8-jdk-jammy
+FROM        --platform=$TARGETOS/$TARGETARCH openjdk:8u312-slim
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -25,6 +25,8 @@
 # latest Forge release. This should be removed when the manifest constructor class
 # issue is backported or if Forge decides to abandon old versions and we need
 # newer Java versions. Old Quay images were updated like once a year, so it's ok.
+#
+# @see https://github.com/McModLauncher/modlauncher/issues/91
 
 FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8u312-b07-jdk-focal
 

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -26,9 +26,11 @@
 # issue is backported or if Forge decides to abandon old versions and we need
 # newer Java versions. Old Quay images were updated like once a year, so it's ok.
 #
+# Update: This issue has been resolved, see issue below for more info - No767 (Noelle)
+# For reference, the old hard coded version is 8u312-slim
 # @see https://github.com/McModLauncher/modlauncher/issues/91
 
-FROM        --platform=$TARGETOS/$TARGETARCH openjdk:8u312-slim
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8-jdk-jammy
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 


### PR DESCRIPTION
OpenJDK Docker images have been completely deprecated for Java 17 and below. As of now, they only support Java 18+. It would be much more advisable to move to a different JDK vendor such as Eclipse Termium instead. This PR replaces those old deprecated OpenJDK images w/ ones from Eclipse Termium. The biggest difference is that these new images are based on Ubuntu 22.04 (Jammy). 