### PR TITLE
Fix installers and OS build

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -19,18 +19,18 @@ jobs:
           - alpine
           - debian
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.5.1"
+          version: "v0.9.1"
           buildkitd-flags: --debug
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: ./oses/${{ matrix.oses }}
           file: ./oses/${{ matrix.oses }}/Dockerfile

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -19,17 +19,17 @@ jobs:
           - source
           - rust
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.5.1"
+          version: "v0.9.1"
           buildkitd-flags: --debug
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: ./games/${{ matrix.game }}
           file: ./games/${{ matrix.game }}/Dockerfile

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,19 +21,19 @@ jobs:
           - 1.16
           - 1.17
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.5.1"
+          version: "v0.9.1"
           buildkitd-flags: --debug
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: ./go
           file: ./go/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -10,7 +10,7 @@ on:
       - installers/**
 jobs:
   push:
-    name: "installers:{{ matrix.tag }}"
+    name: "installers:${{ matrix.tag }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -2,7 +2,7 @@ name: build installers
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * 1"
+    - cron: "0 0 1 * *"
   push:
     branches:
       - master

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -8,9 +8,12 @@ on:
       - master
     paths:
       - installers/**
+
+# Two separate jobs, first for multiarch (amd64, arm64), second for amd64 only
+
 jobs:
-  both:
-    name: "yolks:installer_both:${{ matrix.tag }}"
+  pushMultiArch:
+    name: "yolks:installers_multiarch:${{ matrix.tag }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -23,17 +26,10 @@ jobs:
         with:
           version: "v0.9.1"
           buildkitd-flags: --debug
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+      - name: Setup QEMU for multiarch builds
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64,amd64
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -44,18 +40,12 @@ jobs:
           context: ./installers
           file: ./installers/${{ matrix.tag }}/Dockerfile
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
           push: true
           tags: |
             ghcr.io/pterodactyl/installers:${{ matrix.tag }}
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   pushAmd:
-    name: "yolks:installer_Amd:${{ matrix.tag }}"
+    name: "yolks:installers_amd:${{ matrix.tag }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -64,16 +54,16 @@ jobs:
           - debian
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-buildx-action@v2
         with:
           version: "v0.7.0"
           buildkitd-flags: --debug
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: ./installers
           file: ./installers/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -2,28 +2,71 @@ name: build installers
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 1 * *"
+    - cron: "0 0 * * 1"
   push:
     branches:
       - master
     paths:
       - installers/**
 jobs:
-  push:
-    name: "installers:${{ matrix.tag }}"
+  both:
+    name: "yolks:installer_both:${{ matrix.tag }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         tag:
           - alpine
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+        with:
+          version: "v0.9.1"
+          buildkitd-flags: --debug
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: arm64,amd64
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - uses: docker/build-push-action@v3
+        with:
+          context: ./installers
+          file: ./installers/${{ matrix.tag }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          push: true
+          tags: |
+            ghcr.io/pterodactyl/installers:${{ matrix.tag }}
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  pushAmd:
+    name: "yolks:installer_Amd:${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
           - debian
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
         with:
-          version: "v0.5.1"
+          version: "v0.7.0"
           buildkitd-flags: --debug
       - uses: docker/login-action@v1
         with:
@@ -34,7 +77,7 @@ jobs:
         with:
           context: ./installers
           file: ./installers/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/pterodactyl/installers:${{ matrix.tag }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -26,18 +26,18 @@ jobs:
           - 18
           - 18j9
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.5.1"
+          version: "v0.9.1"
           buildkitd-flags: --debug
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: ./java
           file: ./java/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,19 +23,19 @@ jobs:
           - 17
           - 18
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.5.1"
+          version: "v0.9.1"
           buildkitd-flags: --debug
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: ./nodejs
           file: ./nodejs/${{ matrix.tag }}/Dockerfile

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,19 +22,19 @@ jobs:
           - '3.10'
           - '3.11'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v1
-      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.5.1"
+          version: "v0.9.1"
           buildkitd-flags: --debug
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: ./python
           file: ./python/${{ matrix.tag }}/Dockerfile

--- a/oses/debian/Dockerfile
+++ b/oses/debian/Dockerfile
@@ -6,7 +6,7 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN         apt update && apt upgrade -y \
-				&& apt install -y gcc g++ libgcc1 lib32gcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
+				&& apt install -y gcc g++ libgcc1 libc++-dev gdb libc6 git wget curl tar zip unzip binutils xz-utils liblzo2-2 cabextract iproute2 net-tools netcat telnet libatomic1 libsdl1.2debian libsdl2-2.0-0 \
     			libfontconfig libicu63 icu-devtools libunwind8 libssl-dev sqlite3 libsqlite3-dev libmariadbclient-dev libduktape203 locales ffmpeg gnupg2 apt-transport-https software-properties-common ca-certificates tzdata \
     			liblua5.3 libz-dev rapidjson-dev \
 				&& update-locale lang=en_US.UTF-8 \


### PR DESCRIPTION
The installer and OS builds are failing

what I changed

- installer alpine is build for ARM64 and AMD64
- install Debian is only build for AMD64
- OS Debian package lib32gcc1 is removed as it does not exist on ARM64 and only is needed by steamcmd what will use the source or dedicated steamcmd images from parker or this ones
- Update all workflows to the newest version of the steps
- fix variable in build name as a $ was missing