### PR TITLE
Github actions - remove BuildKit  version pinning

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - name: Setup QEMU for multiarch builds
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         with:
-          version: "v0.9.1"
           buildkitd-flags: --debug
       - uses: docker/login-action@v2
         with:


### PR DESCRIPTION
removed version pinning from Buildkit, to use always the latest stable version, insteed a pinned version.

`Buildkit:  v0.11.2`

This fixes per example:

`buildx failed with: ERROR: failed to solve: failed to push <URL> failed to copy: io: read/write on closed pipe`

More infos:
https://github.com/moby/buildkit/releases/tag/v0.11.2