### PR TITLE
use latest temurin 8 jdk instead of 8u312

### DIFF
--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -28,7 +28,7 @@
 #
 # @see https://github.com/McModLauncher/modlauncher/issues/91
 
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8u312-b07-jdk-focal
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8-jdk-focal
 
 LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
 


### PR DESCRIPTION
This PR will make the java 8 image use latest Temurin Java 8 JDK instead of using 8u312