### PR TITLE
Add support for Carbon, a rust modding framework

### DIFF
--- a/games/rust/entrypoint.sh
+++ b/games/rust/entrypoint.sh
@@ -16,31 +16,23 @@ fi
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
-if [ -f CARBON_FLAG ] || [ "${FRAMEWORK}" == "carbon" ]; then
+if [[ "${FRAMEWORK}" == "carbon" ]]; then
     # Carbon: https://github.com/CarbonCommunity/Carbon.Core
     echo "Updating Carbon..."
     curl -sSL "https://github.com/CarbonCommunity/Carbon.Core/releases/download/production_build/Carbon.Linux.Release.tar.gz" | tar zx
     echo "Done updating Carbon!"
 
-    # backward compatibility
-    export CARBON=1
-
     export DOORSTOP_ENABLED=1
     export DOORSTOP_TARGET_ASSEMBLY="$(pwd)/carbon/managed/Carbon.Preloader.dll"
     MODIFIED_STARTUP="LD_PRELOAD=$(pwd)/libdoorstop.so ${MODIFIED_STARTUP}"
 
-elif [ -f OXIDE_FLAG ] || [ "${FRAMEWORK}" == "oxide" ]; then
+elif [[ "$OXIDE" == "1" ]] || [[ "${FRAMEWORK}" == "oxide" ]]; then
     # Oxide: https://github.com/OxideMod/Oxide.Rust
     echo "Updating uMod..."
     curl -sSL "https://github.com/OxideMod/Oxide.Rust/releases/latest/download/Oxide.Rust-linux.zip" > umod.zip
     unzip -o -q umod.zip
     rm umod.zip
     echo "Done updating uMod!"
-
-    # backward compatibility
-    export OXIDE=1
-    export UMOD=1
-
 # else Vanilla, do nothing
 fi
 

--- a/games/rust/entrypoint.sh
+++ b/games/rust/entrypoint.sh
@@ -16,17 +16,29 @@ fi
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
-# OxideMod has been replaced with uMod
-if [ -f OXIDE_FLAG ] || [ "${OXIDE}" = 1 ] || [ "${UMOD}" = 1 ]; then
+if [ "${FRAMEWORK}" == "carbon" ]; then
+    # Carbon: https://github.com/CarbonCommunity/Carbon.Core
+    echo "Updating Carbon..."
+    curl -sSL "https://github.com/CarbonCommunity/Carbon.Core/releases/download/production_build/Carbon.Linux.Release.tar.gz" | tar zx
+    echo "Done updating Carbon!"
+
+    export DOORSTOP_ENABLED=1
+    export DOORSTOP_TARGET_ASSEMBLY="$(pwd)/carbon/managed/Carbon.Preloader.dll"
+    MODIFIED_STARTUP="LD_PRELOAD=$(pwd)/libdoorstop.so ${MODIFIED_STARTUP}"
+
+elif [ "${FRAMEWORK}" == "oxide" ]; then
+    # Oxide: https://github.com/OxideMod/Oxide.Rust
     echo "Updating uMod..."
     curl -sSL "https://github.com/OxideMod/Oxide.Rust/releases/latest/download/Oxide.Rust-linux.zip" > umod.zip
     unzip -o -q umod.zip
     rm umod.zip
     echo "Done updating uMod!"
+
+# else Vanilla, do nothing
 fi
 
 # Fix for Rust not starting
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)
+export LD_LIBRARY_PATH=$(pwd)/RustDedicated_Data/Plugins/x86_64:$(pwd)
 
 # Run the Server
 node /wrapper.js "${MODIFIED_STARTUP}"

--- a/games/rust/entrypoint.sh
+++ b/games/rust/entrypoint.sh
@@ -16,23 +16,30 @@ fi
 MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 echo ":/home/container$ ${MODIFIED_STARTUP}"
 
-if [ "${FRAMEWORK}" == "carbon" ]; then
+if [ -f CARBON_FLAG ] || [ "${FRAMEWORK}" == "carbon" ]; then
     # Carbon: https://github.com/CarbonCommunity/Carbon.Core
     echo "Updating Carbon..."
     curl -sSL "https://github.com/CarbonCommunity/Carbon.Core/releases/download/production_build/Carbon.Linux.Release.tar.gz" | tar zx
     echo "Done updating Carbon!"
 
+    # backward compatibility
+    export CARBON=1
+
     export DOORSTOP_ENABLED=1
     export DOORSTOP_TARGET_ASSEMBLY="$(pwd)/carbon/managed/Carbon.Preloader.dll"
     MODIFIED_STARTUP="LD_PRELOAD=$(pwd)/libdoorstop.so ${MODIFIED_STARTUP}"
 
-elif [ "${FRAMEWORK}" == "oxide" ]; then
+elif [ -f OXIDE_FLAG ] || [ "${FRAMEWORK}" == "oxide" ]; then
     # Oxide: https://github.com/OxideMod/Oxide.Rust
     echo "Updating uMod..."
     curl -sSL "https://github.com/OxideMod/Oxide.Rust/releases/latest/download/Oxide.Rust-linux.zip" > umod.zip
     unzip -o -q umod.zip
     rm umod.zip
     echo "Done updating uMod!"
+
+    # backward compatibility
+    export OXIDE=1
+    export UMOD=1
 
 # else Vanilla, do nothing
 fi


### PR DESCRIPTION
Not to create additional vars, one for each mod and then needing to validate that the user didn't activated both of them at the same time.. the existing Oxide variable was renamed to "Modding Framework" and accepts three values: "carbon", "oxide" and "vanilla" (default). The names should be self-explanatory about which framework will get deployed on the server instance.

The `entrypoint.sh` file on the rust's docker container was also updated to allow the selection of the modding framework to be used. Carbon uses `UnityDoorstop` as the injector thus it needs additional env context to be setup before starting the dedicated server.