### PR TITLE
Add Java 22 image

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -28,6 +28,7 @@ jobs:
           - 19
           - 19j9
           - 21
+          - 22
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ is tagged correctly.
     * `ghcr.io/pterodactyl/yolks:java_19j9`
   * [`java21`](https://github.com/pterodactyl/yolks/tree/master/java/21)
     * `ghcr.io/pterodactyl/yolks:java_21`
+  * [`java22`](https://github.com/pterodactyl/yolks/tree/master/java/22)
+    * `ghcr.io/pterodactyl/yolks:java_22`
 * [`nodejs`](https://github.com/pterodactyl/yolks/tree/master/nodejs)
   * [`node12`](https://github.com/pterodactyl/yolks/tree/master/nodejs/12)
     * `ghcr.io/pterodactyl/yolks:nodejs_12`

--- a/java/22/Dockerfile
+++ b/java/22/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2021 Matthew Penner
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:22-jdk
+
+LABEL       author="Matthew Penner" maintainer="matthew@pterodactyl.io"
+
+LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.licenses=MIT
+
+RUN 				apt-get update -y \
+						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+						&& useradd -d /home/container -m container
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./../entrypoint.sh /entrypoint.sh
+CMD         [ "/bin/bash", "/entrypoint.sh" ]


### PR DESCRIPTION
This PR adds a yolk for Java 22, which has some optimisations to the Java platform module system (JPMS) that benefits Forge.