### PR TITLE
add support for Node20

### DIFF
--- a/games/rust/Dockerfile
+++ b/games/rust/Dockerfile
@@ -33,7 +33,8 @@ RUN			dpkg --add-architecture i386 \
 			&& apt update \
 			&& apt upgrade -y \
 			&& apt install -y lib32gcc-s1 lib32stdc++6 unzip curl iproute2 tzdata libgdiplus libsdl2-2.0-0:i386 \
-			&& curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+			&& curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh \
+   			&& bash nodesource_setup.sh \
 			&& apt install -y nodejs \
 			&& mkdir /node_modules \
 			&& npm install --prefix / ws \


### PR DESCRIPTION
Adding Node20 to dockerfile - fix for previously failed attempts to upgrade node. Will improve build times by 4x due to no more deprecation messages.