### PR TITLE
Add Support for Argon2 in Java Containers and Optimize Image Size

### DIFF
--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -36,7 +36,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+			&& rm -rf /var/lib/apt/lists/* \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
  			&& useradd -d /home/container -m container
 
 USER        container

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+			&& rm -rf /var/lib/apt/lists/* \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
  			&& useradd -d /home/container -m container
 
 USER        container

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -29,7 +29,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+			&& rm -rf /var/lib/apt/lists/* \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
  			&& useradd -d /home/container -m container
 
 USER        container

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+			&& rm -rf /var/lib/apt/lists/* \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
  			&& useradd -d /home/container -m container
 
 USER        container

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+			&& rm -rf /var/lib/apt/lists/* \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
  			&& useradd -d /home/container -m container
 
 USER        container

--- a/java/17j9/Dockerfile
+++ b/java/17j9/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 				apt-get update -y \
-						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+	  					&& rm -rf /var/lib/apt/lists/* \
+						&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/18/Dockerfile
+++ b/java/18/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+			&& rm -rf /var/lib/apt/lists/* \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
  			&& useradd -d /home/container -m container
 
 USER        container

--- a/java/18j9/Dockerfile
+++ b/java/18j9/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 				apt-get update -y \
-						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+	  					&& rm -rf /var/lib/apt/lists/* \
+						&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
+			&& rm -rf /var/lib/apt/lists/* \
  			&& useradd -d /home/container -m container
 
 USER        container

--- a/java/19j9/Dockerfile
+++ b/java/19j9/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 				apt-get update -y \
-						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+	  					&& rm -rf /var/lib/apt/lists/* \
+						&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/21/Dockerfile
+++ b/java/21/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 				apt-get update -y \
-						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+						&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+	  					&& rm -rf /var/lib/apt/lists/* \
+						&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
 						&& useradd -d /home/container -m container
 
 USER        container

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -36,7 +36,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+	  		&& rm -rf /var/lib/apt/lists/* \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
  			&& useradd -d /home/container -m container
 
 USER        container

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -28,7 +28,9 @@ LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolk
 LABEL       org.opencontainers.image.licenses=MIT
 
 RUN 		apt-get update -y \
- 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 \
+ 			&& apt-get install -y lsof curl ca-certificates openssl git tar sqlite3 fontconfig libfreetype6 tzdata iproute2 libstdc++6 libargon2-dev \
+			&& rm -rf /var/lib/apt/lists/* \
+			&& ln -s /usr/lib/$(arch)-linux-gnu/libargon2.so /usr/lib/libargon2.so \
  			&& useradd -d /home/container -m container
 
 USER        container


### PR DESCRIPTION
#### Summary of Changes
1. **Argon2 Support in Java Containers**:
   - Added support for the Argon2 hashing algorithm in Java-based containers to enhance cryptographic capabilities. 
   - This addition is useful for projects or applications requiring secure password hashing using Argon2. (exemple: https://github.com/AuthMe/AuthMeReloaded/wiki/Argon2-as-Password-Hash)

2. **Reduced Image Size**:
   - Incorporated the command `rm -rf /var/lib/apt/lists/*` to clean up unnecessary apt cache files after package installations.
   - This step reduces the overall image size, improving efficiency and minimizing storage usage.

#### Testing
- Verified the functionality of the Argon2 implementation in supported containers.
- Confirmed that image size reductions do not impact the existing functionality of the containers.

#### Notes
Please review and let me know if additional changes are required. 