### PR TITLE
Fix a number of issues preventing builds.

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:
           context: ./oses/${{ matrix.oses }}

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
+        with:
+            image: tonistiigi/binfmt:qemu-v7.0.0-28
       - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -19,12 +19,12 @@ jobs:
           - alpine
           - debian
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:
           context: ./games/${{ matrix.game }}

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -19,11 +19,11 @@ jobs:
           - source
           - rust
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:
           context: ./go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,13 +21,13 @@ jobs:
           - 1.16
           - 1.17
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
       # Setup QEMU for ARM64 Build
       - uses: docker/setup-qemu-action@v3
+        with:
+            image: tonistiigi/binfmt:qemu-v7.0.0-28
       - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:
           context: ./installers
@@ -61,7 +61,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:
           context: ./installers

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -21,15 +21,15 @@ jobs:
         tag:
           - alpine
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
       - name: Setup QEMU for multiarch builds
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,amd64
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -53,11 +53,11 @@ jobs:
           - debian
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
         with:
           version: "v0.7.0"
           buildkitd-flags: --debug
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -29,6 +29,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,amd64
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:
           context: ./java

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
+        with:
+            image: tonistiigi/binfmt:qemu-v7.0.0-28
       - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -29,12 +29,12 @@ jobs:
           - 19j9
           - 21
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:
           context: ./nodejs

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,13 +24,13 @@ jobs:
           - 18
           - 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@v4
       # Setup QEMU for ARM64 Build
       - uses: docker/setup-qemu-action@v3
+        with:
+            image: tonistiigi/binfmt:qemu-v7.0.0-28
       - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v4
         with:
           context: ./python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       # Setup QEMU for ARM64 Build
       - uses: docker/setup-qemu-action@v3
+        with:
+            image: tonistiigi/binfmt:qemu-v7.0.0-28
       - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,13 +22,13 @@ jobs:
           - '3.10'
           - '3.11'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup QEMU for ARM64 Build
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
         with:
           buildkitd-flags: --debug
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/games/source/Dockerfile
+++ b/games/source/Dockerfile
@@ -32,7 +32,7 @@ ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
 				&& apt update \
 				&& apt upgrade -y \
-				&& apt install -y tar curl gcc g++ lib32gcc-s1 libgcc1 libcurl4-gnutls-dev:i386 libssl1.1:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat tzdata \
+				&& apt install -y tar curl gcc g++ lib32gcc-s1 libgcc1 libcurl4-gnutls-dev:i386 libssl3:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata \
 				&& useradd -m -d /home/container container
 
 USER        container


### PR DESCRIPTION
Source: Update packages for Debian bookworm
ci: Hotfix: Pin qemu-action to qemu-v7.0.0-28
ci: Bump actions versions
ci: Use GitHub token for registry


Please merge *without* squashing.



