### PR TITLE
Add support for the ppc64le architecture

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           context: ./oses/${{ matrix.oses }}
           file: ./oses/${{ matrix.oses }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           push: true
           tags: |
             ghcr.io/pterodactyl/yolks:${{ matrix.oses }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           context: ./go
           file: ./go/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/ppc64le
           push: true
           tags: |
             ghcr.io/pterodactyl/yolks:go_${{ matrix.tag }}

--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - installers/**
 
-# Two separate jobs, first for multiarch (amd64, arm64), second for amd64 only
+# Two separate jobs, first for multiarch (amd64, arm64, ppc64le), second for amd64 only
 
 jobs:
   pushMultiArch:
@@ -28,7 +28,7 @@ jobs:
       - name: Setup QEMU for multiarch builds
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: arm64,amd64
+          platforms: ppc64le,arm64,amd64
           image: tonistiigi/binfmt:qemu-v7.0.0-28
       - uses: docker/login-action@v3
         with:
@@ -39,7 +39,7 @@ jobs:
         with:
           context: ./installers
           file: ./installers/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           push: true
           tags: |
             ghcr.io/pterodactyl/installers:${{ matrix.tag }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -41,11 +41,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - id: platforms
+        run: |
+          PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le"
+          if [[ "${{ matrix.tag }}" == *"j9"* ]]; then
+            PLATFORMS="linux/amd64,linux/arm64"
+          fi
       - uses: docker/build-push-action@v4
         with:
           context: ./java
           file: ./java/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.platforms.outputs.platforms }}
           push: true
           tags: |
             ghcr.io/pterodactyl/yolks:java_${{ matrix.tag }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           context: ./nodejs
           file: ./nodejs/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           push: true
           tags: |
             ghcr.io/pterodactyl/yolks:nodejs_${{ matrix.tag }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           context: ./python
           file: ./python/${{ matrix.tag }}/Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/ppc64le
           push: true
           tags: |
             ghcr.io/pterodactyl/yolks:python_${{ matrix.tag }}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ and network usage by pre-installing common installation dependencies such as `cu
 a specific version of software and allow different Eggs within Pterodactyl to switch out the underlying implementation. An
 example of this would be something like Java or Python which are used for running bots, Minecraft servers, etc.
 
-All of these images are available for `linux/amd64` and `linux/arm64` versions, unless otherwise specified, to use
-these images on an arm64 system, no modification to them or the tag is needed, they should just work.
+All of these images are available for `linux/amd64`, `linux/arm64`, and `linux/ppc64le` versions, unless otherwise specified, to use
+these images on an arm64 or ppc64le system, no modification to them or the tag is needed, they should just work.
 
 ## Contributing
 


### PR DESCRIPTION
This adds support for building the docker images for the `ppc64le` architecture. This is used on IBM POWER servers, and also on high end workstations like the Talos II from Raptor Computing Systems.

This adds the architecture to the following workflows:
- java
- installers
- python
- base
- go
- nodejs

For the installer, this adds the new architecture to the multiarch build. For Java, I excluded the architecture from the `j9` builds, as support is missing from `java_18j9` and  `java_19j9`.

I've been running a bunch of Minecraft servers manually on my Talos II for years, and would love to migrate them all to Pterodactyl!

I'm also opened a pull request to add support for this architecture to wings, which I have successfully compiled for the system: https://github.com/pterodactyl/wings/pull/283

I successfully built the images with Github actions on my own profile: https://github.com/Ry6000?tab=packages&repo_name=yolks , with the exception of the actions that are also failing in master (yolks:debian and games:source). Note that I didn't add the architecture for games, as I don't believe there are binaries for the server software for the games on this architecture.

After modifying the vanilla Minecraft egg to point to my installer docker image, uploading it to the panel, and starting wings built for `ppc64e`, the server works perfectly!

Please let me know if you have any questions or comments; I am happy more than happy to answer. 😄 

Some screenshots of everything running:

<img width="1799" height="1129" alt="ppc64le_panel" src="https://github.com/user-attachments/assets/be3ad605-7e9d-480a-a954-819ca7811f6f" />
<img width="1926" height="879" alt="talos_system" src="https://github.com/user-attachments/assets/842295b3-0427-4fc1-a115-5197876aa8c6" />
<img width="1454" height="824" alt="Screen Shot 2025-11-09 at 5 01 08 AM" src="https://github.com/user-attachments/assets/ac0adaf1-abf9-42c6-8c27-04b0f61c3d17" />

