### PR TITLE
Fix link for java25 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ is tagged correctly.
     * `ghcr.io/pterodactyl/yolks:java_19j9`
   * [`java21`](https://github.com/pterodactyl/yolks/tree/master/java/21)
     * `ghcr.io/pterodactyl/yolks:java_21`
-  * [`java21`](https://github.com/pterodactyl/yolks/tree/master/java/25)
+  * [`java25`](https://github.com/pterodactyl/yolks/tree/master/java/25)
     * `ghcr.io/pterodactyl/yolks:java_25`
 * [`nodejs`](https://github.com/pterodactyl/yolks/tree/master/nodejs)
   * [`node12`](https://github.com/pterodactyl/yolks/tree/master/nodejs/12)


### PR DESCRIPTION
This pull request corrects a documentation error in the `README.md` file, ensuring the Java 25 image is properly referenced.

- Documentation fix:
  * Corrected the link label from `java21` to `java25` for the Java 25 image, so it accurately reflects the image version.