### PR TITLE
Games/Hytale - Fake Machine ID 

### DIFF
--- a/games/hytale/Dockerfile
+++ b/games/hytale/Dockerfile
@@ -33,7 +33,7 @@ COPY        --from=ghcr.io/pterodactyl/yolks:java_25 entrypoint.sh /java.sh
 RUN 		chmod +x /java.sh
 
 RUN			apt-get update -y \
-				&& apt-get install -y unzip jq \
+				&& apt-get install -y unzip jq xxd \
 				&& rm -rf /var/lib/apt/lists/*
 
 USER        container

--- a/games/hytale/entrypoint.sh
+++ b/games/hytale/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Generate machine-id if it doesn't exist
+if [[ ! -f /etc/machine-id ]]; then
+	dd if=/dev/urandom bs=16 count=1 2>/dev/null | xxd -p -c 16 | sudo tee /etc/machine-id >/dev/null
+fi
+
 cd /home/container
 
 # If HYTALE_SERVER_SESSION_TOKEN isn't set, assume the user will log in themselves, rather than a host's GSP


### PR DESCRIPTION
This update will create a fake /etc/machine-id separate for each so login persists on Hytale.

This should fix:
https://github.com/pterodactyl/game-eggs/issues/385

Obviously the other fix could be to mount the real /etc/machine-id to the docker container but I think this would generally be ill advised as would cause issues moving the server between nodes.