### PR TITLE
Add support for the arm architecture, respect Hytale's default folder location & add support for hytale's updater

### DIFF
--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -9,7 +9,33 @@ on:
     paths:
       - games/**
 jobs:
-  push:
+  pushMultiArch:
+    name: "games:${{ matrix.game }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        game:
+          - hytale
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v4
+        with:
+          context: ./games/${{ matrix.game }}
+          file: ./games/${{ matrix.game }}/Dockerfile
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: |
+            ghcr.io/pterodactyl/games:${{ matrix.game }}
+  pushAmd:
     name: "games:${{ matrix.game }}"
     runs-on: ubuntu-latest
     strategy:
@@ -18,7 +44,6 @@ jobs:
         game:
           - source
           - rust
-          - hytale
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3

--- a/games/hytale/Dockerfile
+++ b/games/hytale/Dockerfile
@@ -29,11 +29,38 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 USER		root
 
-COPY        --from=ghcr.io/pterodactyl/yolks:java_25 entrypoint.sh /java.sh
+RUN 		printf '%s\n' \
+			'#!/bin/bash' \
+			'# Default the TZ environment variable to UTC.' \
+			'TZ=${TZ:-UTC}' \
+			'export TZ' \
+			'' \
+			'# Set environment variable that holds the Internal Docker IP' \
+			"INTERNAL_IP=\$(ip route get 1 | awk '{print \$(NF-2);exit}')" \
+			'export INTERNAL_IP' \
+			'' \
+			"# Switch to the container's working directory" \
+			'cd /home/container/Server || exit 1' \
+			'' \
+			'# Print Java version' \
+			'printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0mjava -version\n"' \
+			'java -version' \
+			'' \
+			'# Convert all of the "{{VARIABLE}}" parts of the command into the expected shell' \
+			'# variable format of "${VARIABLE}" before evaluating the string and automatically' \
+			'# replacing the values.' \
+			"PARSED=\$(echo \"\${STARTUP}\" | sed -e 's/{{/\${/g' -e 's/}}/}/g' | eval echo \"\$(cat -)\")" \
+			'' \
+			"# Display the command we're running in the output, and then execute it with the env" \
+			'# from the container itself.' \
+			'printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0m%s\n" "$PARSED"' \
+			'# shellcheck disable=SC2086' \
+			'exec env ${PARSED}' > /java.sh
+
 RUN 		chmod +x /java.sh
 
 RUN			apt-get update -y \
-				&& apt-get install -y unzip jq \
+				&& apt-get install -y unzip jq qemu-user-static \
 				&& rm -rf /var/lib/apt/lists/*
 
 USER        container

--- a/games/hytale/entrypoint.sh
+++ b/games/hytale/entrypoint.sh
@@ -3,30 +3,91 @@ set -e
 
 cd /home/container
 
+# Migration from old path to new path
+if [[ -f ./config.json || -f ./HytaleServer.jar || -f ./HytaleServer.aot || -f ./whitelist.json || -f ./bans.json || -f ./whitelist.json ]]; then
+	if [[ ! -d "/home/container/Server" ]]; then
+		mkdir -p /home/container/Server
+	fi
+	mv ./Licenses ./Server
+	mv ./logs ./Server
+	mv ./mods ./Server
+	mv ./universe ./Server
+	mv ./auth.enc ./Server
+	mv ./bans.json ./Server
+	mv ./config.json ./Server
+	mv ./config.json.bak ./Server
+	mv ./HytaleServer.jar ./Server
+	mv ./HytaleServer.aot ./Server
+	mv ./permissions.json ./Server
+	mv ./whitelist.json ./Server
+fi
+
+# Respect the user's patchline wish, if they so choose to change it from the server console
+if [[ -f ./Server/config.json ]]; then
+	if [[ ! -z "$(jq -r '.Update.Patchline // ""' ./Server/config.json)" ]]; then
+		CONFIG_PATCHLINE=$(jq -r '.Update.Patchline // ""' ./Server/config.json)
+		if [[ "$HYTALE_PATCHLINE" != "$CONFIG_PATCHLINE" ]]; then
+			HYTALE_PATCHLINE="$CONFIG_PATCHLINE"
+		fi
+	fi
+fi
+
 # If HYTALE_SERVER_SESSION_TOKEN isn't set, assume the user will log in themselves, rather than a host's GSP
 if [[ -z "$HYTALE_SERVER_SESSION_TOKEN" ]]; then
-
-	echo -e "Checking for Hytale server update..."
-
-	if [[ -f version ]]; then
-		curversion=$(./hytale-downloader/hytale-downloader-linux -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
+	if [[ "$(uname -m)" == "aarch64" ]]; then
+		HYTALE_DOWNLOADER="qemu-x86_64-static ./hytale-downloader/hytale-downloader-linux"
+	else
+		HYTALE_DOWNLOADER="./hytale-downloader/hytale-downloader-linux"
 	fi
 
-	if ! [[ -e version ]] || [ "$curversion" != "$(cat "version")" ]; then
-		if [[ -f version ]]; then
+	# Apply staged update if present
+	if [[ -f "./updater/staging/Server/HytaleServer.jar" ]]; then
+		curversion=$($HYTALE_DOWNLOADER -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
+		echo "[Launcher] Applying $curversion update..."
+		# Only replace update files, preserve config.json/universe/mods
+		cp -f ./updater/staging/Server/HytaleServer.jar ./Server/
+		if [[ -f "./updater/staging/Server/HytaleServer.aot" ]]; then
+			cp -f ./updater/staging/Server/HytaleServer.aot ./Server/
+		fi
+		if [[ -d "./updater/staging/Server/Licenses" ]]; then
+			rm -rf ./Server/Licenses
+			cp -r ./updater/staging/Server/Licenses ./Server
+		fi
+		if [[ -f "./updater/staging/Assets.zip" ]]; then
+			cp -f ./updater/staging/Assets.zip ./
+		fi
+		#if [[ -f ".updater/staging/start.sh" ]]; then
+		#	cp -f ./updater/staging/start.sh ./
+		#fi
+		#if [[ -f ".updater/staging/start.bat" ]]; then
+		#	cp -f ./updater/staging/start.bat ./
+		#fi
+
+		rm -rf ./updater/staging
+		echo "$curversion" > ./version
+	fi
+	
+	echo -e "Checking for Hytale server update..."
+
+	if [[ -f ./version ]]; then
+		curversion=$("$HYTALE_DOWNLOADER" -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
+	fi
+
+	if ! [[ -e ./version ]] || [ "$curversion" != "$(cat "./version")" ]; then
+		if [[ -f ./version ]]; then
 			echo -e "New update available, downloading version $curversion..."
 		fi
 
-		./hytale-downloader/hytale-downloader-linux -patchline "$HYTALE_PATCHLINE" -download-path HytaleServer.zip
+		"$HYTALE_DOWNLOADER" -patchline "$HYTALE_PATCHLINE" -download-path HytaleServer.zip
 
 		# Write the current version if it wasn't set before
 		if [[ -z "$curversion" ]]; then
-			curversion=$(./hytale-downloader/hytale-downloader-linux -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
+			curversion=$("$HYTALE_DOWNLOADER" -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
 		fi
 
-		unzip -o HytaleServer.zip -d .
-		rm -f HytaleServer.zip
-		echo "$curversion" > version
+		unzip -o ./HytaleServer.zip -d .
+		rm -f ./HytaleServer.zip
+		echo "$curversion" > ./version
 	fi
 
 elif [[ -f "HytaleMount/HytaleServer.zip" ]]; then
@@ -39,22 +100,66 @@ elif [[ -f "HytaleServer.zip" ]]; then
 	unzip -o HytaleServer.zip -d .
 fi
 
+# Removing launch scripts, because I don't believe them to be necessary.
+# Updating server via /update download will cry about
+# "Expected Assets.zip and launcher scripts in parent directory."
+# But one can force it with /update download --force.
+# If auto-update is the goal, just delete or comment the bottom 2 if-blocks.
+if [[ -f start.bat ]]; then
+	rm start.bat
+fi
+if [[ -f start.sh ]]; then
+	rm start.sh
+fi
+
 # Download the latest hytale-sourcequery plugin if enabled
 if [ "${INSTALL_SOURCEQUERY_PLUGIN}" == "1" ]; then
-	mkdir -p mods
+	mkdir -p ./Server/mods
 	echo -e "Downloading latest hytale-sourcequery plugin..."
 	LATEST_URL=$(curl -sSL https://api.github.com/repos/physgun-com/hytale-sourcequery/releases/latest \
 		| grep -oP '"browser_download_url":\s*"\K[^"]+\.jar' || true)
 	if [[ -n "$LATEST_URL" ]]; then
-		curl -sSL -o mods/hytale-sourcequery.jar "$LATEST_URL"
+		curl -sSL -o ./Server/mods/hytale-sourcequery.jar "$LATEST_URL"
 		echo -e "Successfully downloaded hytale-sourcequery plugin to mods folder."
 	else
 		echo -e "Warning: Could not find hytale-sourcequery plugin download URL."
 	fi
 fi
 
-if [[ -f config.json && -n "$HYTALE_MAX_VIEW_RADIUS" ]]; then
-	jq ".MaxViewRadius = $HYTALE_MAX_VIEW_RADIUS" config.json > config.tmp.json && mv config.tmp.json config.json
+if [[ -f ./Server/config.json && -n "$HYTALE_MAX_VIEW_RADIUS" ]]; then
+	jq ".MaxViewRadius = $HYTALE_MAX_VIEW_RADIUS" ./Server/config.json > ./Server/config.tmp.json && mv ./Server/config.tmp.json ./Server/config.json
+fi
+
+if [[ ! -d "/home/container/Server" ]]; then
+	mkdir -p /home/container/Server
+fi
+cd /home/container/Server
+
+if [[ "${STARTUP:-}" =~ -jar\ Server/HytaleServer\.jar || "${0}" =~ -jar\ Server/HytaleServer\.jar ]]; then
+  echo ""
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "!!                        OUTDATED STARTUP DETECTED                  !!"
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo ""
+  echo "ERROR: Your startup command still uses 'Server/HytaleServer.jar'"
+  echo "       That's an outdated path from early versions of this Hytale egg."
+  echo ""
+  echo "What would happen on continued use:"
+  echo " - Server files (universe/, config.json, logs/, backups/, etc.) are"
+  echo "   generated in the wrong directory: /home/container"
+  echo "   instead of the intended /home/container/Server directory."
+  echo "   Ever since Hytale version 2026.01.24-6e2d4fc36"
+  echo "   server files must be located in /home/container/Server"
+  echo "   Additionally, the Server will not boot"
+  echo "   because we run exit 1 upon detecting Server/HytaleServer.jar used"
+  echo ""
+  echo "To do:"
+  echo " 1. Update to the latest Hytale egg version"
+  echo ""
+  echo "Server startup aborted to prevent usage on wrong path."
+  echo "Update the egg and restart."
+  echo ""
+  exit 1
 fi
 
 /java.sh $@

--- a/games/hytale/entrypoint.sh
+++ b/games/hytale/entrypoint.sh
@@ -3,6 +3,33 @@ set -e
 
 cd /home/container
 
+if [[ "${STARTUP:-}" =~ -jar\ Server/HytaleServer\.jar || "${0}" =~ -jar\ Server/HytaleServer\.jar ]]; then
+  echo ""
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "!!                        OUTDATED STARTUP DETECTED                  !!"
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo ""
+  echo "ERROR: Your startup command still uses 'Server/HytaleServer.jar'"
+  echo "       That's an outdated path from early versions of this Hytale egg."
+  echo ""
+  echo "What would happen on continued use:"
+  echo " - Server files (universe/, config.json, logs/, backups/, etc.) are"
+  echo "   generated in the wrong directory: /home/container"
+  echo "   instead of the intended /home/container/Server directory."
+  echo "   Ever since Hytale version 2026.01.24-6e2d4fc36"
+  echo "   server files must be located in /home/container/Server"
+  echo "   Additionally, the Server will not boot"
+  echo "   because we run exit 1 upon detecting Server/HytaleServer.jar used"
+  echo ""
+  echo "To do:"
+  echo " 1. Update to the latest Hytale egg version"
+  echo ""
+  echo "Server startup aborted to prevent usage on wrong path."
+  echo "Update the egg and restart."
+  echo ""
+  exit 1
+fi
+
 # Migration from old path to new path
 if [[ -f ./config.json || -f ./HytaleServer.jar || -f ./HytaleServer.aot || -f ./whitelist.json || -f ./bans.json || -f ./whitelist.json ]]; then
 	if [[ ! -d "/home/container/Server" ]]; then
@@ -134,32 +161,5 @@ if [[ ! -d "/home/container/Server" ]]; then
 	mkdir -p /home/container/Server
 fi
 cd /home/container/Server
-
-if [[ "${STARTUP:-}" =~ -jar\ Server/HytaleServer\.jar || "${0}" =~ -jar\ Server/HytaleServer\.jar ]]; then
-  echo ""
-  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-  echo "!!                        OUTDATED STARTUP DETECTED                  !!"
-  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-  echo ""
-  echo "ERROR: Your startup command still uses 'Server/HytaleServer.jar'"
-  echo "       That's an outdated path from early versions of this Hytale egg."
-  echo ""
-  echo "What would happen on continued use:"
-  echo " - Server files (universe/, config.json, logs/, backups/, etc.) are"
-  echo "   generated in the wrong directory: /home/container"
-  echo "   instead of the intended /home/container/Server directory."
-  echo "   Ever since Hytale version 2026.01.24-6e2d4fc36"
-  echo "   server files must be located in /home/container/Server"
-  echo "   Additionally, the Server will not boot"
-  echo "   because we run exit 1 upon detecting Server/HytaleServer.jar used"
-  echo ""
-  echo "To do:"
-  echo " 1. Update to the latest Hytale egg version"
-  echo ""
-  echo "Server startup aborted to prevent usage on wrong path."
-  echo "Update the egg and restart."
-  echo ""
-  exit 1
-fi
 
 /java.sh $@

--- a/games/hytale/entrypoint.sh
+++ b/games/hytale/entrypoint.sh
@@ -97,7 +97,7 @@ if [[ -z "$HYTALE_SERVER_SESSION_TOKEN" ]]; then
 	echo -e "Checking for Hytale server update..."
 
 	if [[ -f ./version ]]; then
-		curversion=$("$HYTALE_DOWNLOADER" -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
+		curversion=$($HYTALE_DOWNLOADER -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
 	fi
 
 	if ! [[ -e ./version ]] || [ "$curversion" != "$(cat "./version")" ]; then
@@ -105,11 +105,11 @@ if [[ -z "$HYTALE_SERVER_SESSION_TOKEN" ]]; then
 			echo -e "New update available, downloading version $curversion..."
 		fi
 
-		"$HYTALE_DOWNLOADER" -patchline "$HYTALE_PATCHLINE" -download-path HytaleServer.zip
+		$HYTALE_DOWNLOADER -patchline "$HYTALE_PATCHLINE" -download-path HytaleServer.zip
 
 		# Write the current version if it wasn't set before
 		if [[ -z "$curversion" ]]; then
-			curversion=$("$HYTALE_DOWNLOADER" -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
+			curversion=$($HYTALE_DOWNLOADER -patchline "$HYTALE_PATCHLINE" -print-version | tee /dev/tty)
 		fi
 
 		unzip -o ./HytaleServer.zip -d .

--- a/games/hytale/entrypoint.sh
+++ b/games/hytale/entrypoint.sh
@@ -8,18 +8,18 @@ if [[ -f ./config.json || -f ./HytaleServer.jar || -f ./HytaleServer.aot || -f .
 	if [[ ! -d "/home/container/Server" ]]; then
 		mkdir -p /home/container/Server
 	fi
-	mv ./Licenses ./Server
-	mv ./logs ./Server
-	mv ./mods ./Server
-	mv ./universe ./Server
-	mv ./auth.enc ./Server
-	mv ./bans.json ./Server
-	mv ./config.json ./Server
-	mv ./config.json.bak ./Server
-	mv ./HytaleServer.jar ./Server
-	mv ./HytaleServer.aot ./Server
-	mv ./permissions.json ./Server
-	mv ./whitelist.json ./Server
+	mv ./Licenses ./Server || true
+	mv ./logs ./Server || true
+	mv ./mods ./Server || true
+	mv ./universe ./Server || true
+	mv ./auth.enc ./Server || true
+	mv ./bans.json ./Server || true
+	mv ./config.json ./Server || true
+	mv ./config.json.bak ./Server || true
+	mv ./HytaleServer.jar ./Server || true
+	mv ./HytaleServer.aot ./Server || true
+	mv ./permissions.json ./Server || true
+	mv ./whitelist.json ./Server || true
 fi
 
 # Respect the user's patchline wish, if they so choose to change it from the server console


### PR DESCRIPTION
PTERO-EGGS UPDATE NECESSARY FIRST!!!!
More as to why this is so important later in this post.

This adds support for building docker images for arm.
I believe waiting for official support to be futile because enough time has passed, and there is no wrongdoing in using QEMU to support arm.
Even if official support gets in at some point in the future, it will still work with QEMU and can be removed later on regardless.

Now on to Hytale's default folder location.
What we've been doing so far was not good.
Essentially, the server should generate it's files inside /home/container/Server, not /home/container.
Best way to replicate it is by running the following commands on a running server that is authenticated:
/auth login device
/update check
/update patchline pre-release
/update check
/update download
This command above is what will warn that it expects Assets.zip + launcher scripts in parent directory, and that's fine, we can force it with the next command
/update download --force
But that's where it's game over for us.
Hytale's updater tries to go 1 directory back, then into the updater directory, however there are no permissions to go inside /home, there it fails with "Read-only file system":
<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/404b15aa-8c43-4c5a-9455-25baa575f2c0" />

My PR attempts to fix that by changing Hytale's Dockerfile by literally removing the COPY command COPY        --from=ghcr.io/pterodactyl/yolks:java_25 entrypoint.sh /java.sh and manually recreating the file with the correct directory Hytale needs.
I dont know if there's a better solution, but this one is what worked and I dont see many downsides from it.

Additionally, any user that has files inside /home/container that should belong to /home/container/Server will be having them moved over to the Server directory.

Since we now have to default to a specific directory, this is where the dependency of an update to Hytale's egg is necessary.
The current egg uses Server/HytaleServer.jar to launch the Server, but it needs to be updated to ./HytaleServer.jar, as the current working directory needs to be /home/container/Server anyways, therefore this update also does not let anyone boot their server unless they either update the egg, or the startup script to not contain any of the launch arguments + Server/HytaleServer.jar

The updater logic is reimplemented from the start.sh file Hytale provides ever since version 2026.01.24-6e2d4fc36, therefore that's where it can be found.

